### PR TITLE
Addressing dependabot alerts

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 dj-database-url
-django>=3.2.16
+django==3.2.18
 django-environ
 django-jquery
 psycopg2-binary
@@ -14,7 +14,7 @@ libsass
 scss
 whitenoise
 gunicorn
-oauthlib==3.2.1
+oauthlib==3.2.2
 
 # Dependabot Fixes
 certifi==2022.12.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ charset-normalizer==2.0.4
     # via requests
 dj-database-url==0.5.0
     # via -r requirements.in
-django==3.2.16
+django==3.2.18
     # via
     #   -r requirements.in
     #   django-govuk-forms
@@ -38,7 +38,7 @@ idna==3.2
     # via requests
 libsass==0.21.0
     # via -r requirements.in
-oauthlib==3.2.1
+oauthlib==3.2.2
     # via
     #   -r requirements.in
     #   requests-oauthlib


### PR DESCRIPTION
Bump django from 3.2.16 to 3.2.18
Bump oauthlib from 3.2.1 to 3.2.2